### PR TITLE
Remove unnecessary request_animation_frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Now the app should be served at `http://127.0.0.1:3000`
 ## Special requirements
 
 * All server functions (`#[server]`) **must** be explicitly registered (see usage sample below). In native code, Leptos uses a clever macro to register them automatically; unfortunately, that doesn't work in WASI.
-* Event handlers in views **must** be wrapped in `leptos::request_animation_frame` ([more info](https://leptos-rs.github.io/leptos/ssr/24_hydration_bugs.html#mismatches-between-server-and-client-code)). I am not sure if this is fundamental or if the requirement can be removed as we improve the integration.
-* Resources currently do not work as an upstream fix is needed (and is in progress). Similar issues may affect other server code - we have not tested very exhaustively yet!
 
 ## Usage
 

--- a/templates/leptos-ssr/content/src/app.rs
+++ b/templates/leptos-ssr/content/src/app.rs
@@ -32,11 +32,9 @@ fn HomePage() -> impl IntoView {
     // Creates a reactive value to update the button
     let (count, set_count) = create_signal(0);
     let on_click = move |_| {
-        request_animation_frame(move || { // !!! IMPORTANT !!! You must use request_enimation_frame
-            set_count.update(|count| *count += 1);
-            spawn_local(async move {
-                save_count(count.get()).await.unwrap(); // YOLO
-            });
+        set_count.update(|count| *count += 1);
+        spawn_local(async move {
+            save_count(count.get()).await.unwrap();
         });
     };
 


### PR DESCRIPTION
Greg from Leptos noted that it should be unnecessary to call `request_animation_frame` in event handlers, and he was right - it was a hangover from a previous effort to get it working.  This PR removes it.