### PR TITLE
Update to Leptos 0.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.29"
-leptos = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d", features = ["ssr", "spin"] }
-leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d" }
-leptos_meta = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d", features = ["ssr"] }
-leptos_router = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d", features = ["ssr"] }
+leptos = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5", features = ["ssr", "spin"] }
+leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos",tag = "v0.5.5" }
+leptos_meta = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5", features = ["ssr"] }
+leptos_router = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5", features = ["ssr"] }
 routefinder = { version = "0.5.3" }
 spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.0.1" }
 url = "2.4.1"

--- a/templates/leptos-ssr/content/Cargo.toml
+++ b/templates/leptos-ssr/content/Cargo.toml
@@ -13,10 +13,10 @@ anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
 http = "0.2"
-leptos = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d" }
-leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d", optional = true }
-leptos_meta = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d" }
-leptos_router = { git = "https://github.com/leptos-rs/leptos", rev = "6014a70d0def869f12282d2df8b6c442a012964d" }
+leptos = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5" }
+leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5", optional = true }
+leptos_meta = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5" }
+leptos_router = { git = "https://github.com/leptos-rs/leptos", tag = "v0.5.5" }
 leptos-spin = { git = "https://github.com/fermyon/leptos-spin", branch = "main", optional = true }
 serde = "1.0.192"
 spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.0.1", optional = true }


### PR DESCRIPTION
There seems to an odd SDK linking issue when I reference Leptos via crates.io.  I've raised this with Spin folks.  In the meantime this at least updates us to a released version of Leptos, even if still via Git.