### PR TITLE
GitHub workflow to publish macros crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-dry-run:
+    name: "Perform dry run for publish"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Check crate publish
+        run: cargo publish --dry-run -p leptos-spin-macro
+
+  release:
+    name: "Publish to crates.io"
+    needs: publish-dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Log into Crates.io
+        run: cargo login ${CRATES_IO_TOKEN}
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Publish crate
+        run: cargo publish -p leptos-spin-macro


### PR DESCRIPTION
This is a minimal release workflow to unblock publishing the macro crate that's needed for Leptos.

Limitations:

* Manual dispatch
* Does not update the version number (use a PR to do that before running)
* Does not create a matching GitHub release
* Does not publish the main `leptos-spin` crate (dry-run got mad that the sibling dependency to `leptos-spin-macro` didn't specify a version)

We can iterate on all this stuff - right now unblocking @benwis is the priority!