### PR TITLE
Publish workflows for both crates

### DIFF
--- a/.github/workflows/release-leptos-spin-macro.yml
+++ b/.github/workflows/release-leptos-spin-macro.yml
@@ -1,0 +1,43 @@
+name: Release leptos-spin-macro
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-dry-run:
+    name: "Perform dry run for publish"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Check macro crate publish
+        run: cargo publish --dry-run -p leptos-spin-macro
+
+  release:
+    name: "Publish to crates.io"
+    needs: publish-dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Log into Crates.io
+        run: cargo login ${CRATES_IO_TOKEN}
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Publish macro crate
+        run: cargo publish -p leptos-spin-macro

--- a/.github/workflows/release-leptos-spin.yml
+++ b/.github/workflows/release-leptos-spin.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release leptos-spin
 
 on:
   workflow_dispatch:
@@ -17,8 +17,8 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Check crate publish
-        run: cargo publish --dry-run -p leptos-spin-macro
+      - name: Check main crate publish
+        run: cargo publish --dry-run -p leptos-spin
 
   release:
     name: "Publish to crates.io"
@@ -39,5 +39,5 @@ jobs:
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
-      - name: Publish crate
-        run: cargo publish -p leptos-spin-macro
+      - name: Publish main crate
+        run: cargo publish -p leptos-spin


### PR DESCRIPTION
This tentatively proposes separate workflows for each crate.  This allows us to release leptos-spin without re-releasing leptos-spin-macro, as they are independent and likely to change at different rates.  If this doesn't work out we can easily combine the publish operations.