### PR TITLE
Template can now use crates.io references

### DIFF
--- a/templates/leptos-ssr/content/Cargo.toml
+++ b/templates/leptos-ssr/content/Cargo.toml
@@ -13,14 +13,13 @@ anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
 http = "0.2"
-leptos = "0.6.5"
-leptos_integration_utils = { version = "0.6.5", optional = true }
-leptos_meta = "0.6.5"
-leptos_router = "0.6.5"
-leptos-spin = { git = "https://github.com/fermyon/leptos-spin", tag = "v0.1.0", optional = true }
-leptos-spin-macro = { git = "https://github.com/fermyon/leptos-spin", tag = "v0.1.0" }
+leptos = "0.6.6"
+leptos_integration_utils = { version = "0.6.6", optional = true }
+leptos_meta = "0.6.6"
+leptos_router = "0.6.6"
+leptos-spin = { version = "0.1.0", optional = true }
 serde = "1.0.192"
-spin-sdk = { version = "2.1", optional = true }
+spin-sdk = { version = "2.2", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
 [workspace]

--- a/templates/leptos-ssr/content/src/app.rs
+++ b/templates/leptos-ssr/content/src/app.rs
@@ -1,7 +1,6 @@
 use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
-use leptos_spin_macro::server;
 
 #[component]
 pub fn App() -> impl IntoView {


### PR DESCRIPTION
@benwis This will have new applications start with crates.io references instead of Git ones.  It seems to build and run correctly against the crates.io version of Leptos, which makes sense as that doesn't yet have any reference to the Spin macro crate.  Are you okay with me updating to this now, or is it better to hold off until you've merged the server reference into the Leptos core?
