### PR TITLE
Add server side redirects for basic forms and action forms with no js

### DIFF
--- a/leptos-spin/Cargo.toml
+++ b/leptos-spin/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/fermyon/leptos-spin"
 dashmap = "5.5.3"
 futures = "0.3.29"
 
-<<<<<<< HEAD
 leptos = { version = "0.6.9", features = ["ssr", "spin"] }
 leptos_integration_utils = { version = "0.6.9" }
 leptos_meta = { version = "0.6.9", features = ["ssr"] }

--- a/leptos-spin/Cargo.toml
+++ b/leptos-spin/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/fermyon/leptos-spin"
 dashmap = "5.5.3"
 futures = "0.3.29"
 
+<<<<<<< HEAD
 leptos = { version = "0.6.9", features = ["ssr", "spin"] }
 leptos_integration_utils = { version = "0.6.9" }
 leptos_meta = { version = "0.6.9", features = ["ssr"] }

--- a/leptos-spin/src/response_options.rs
+++ b/leptos-spin/src/response_options.rs
@@ -15,7 +15,10 @@ impl ResponseOptions {
         let mut inner = self.inner.write().unwrap();
         inner.status = Some(status);
     }
-
+    pub fn status_is_set(&self) -> bool {
+        let inner = self.inner.read().unwrap();
+        inner.status.is_some()
+    }
     pub fn headers(&self) -> Headers {
         self.inner.read().unwrap().headers.clone()
     }
@@ -30,7 +33,7 @@ impl ResponseOptions {
     // Creates a ResponseOptions object with a default 200 status and no headers
     // Useful for server functions
     pub fn default_without_headers() -> Self {
-        Self{
+        Self {
             inner: Arc::new(RwLock::new(ResponseOptionsInner::default_without_headers())),
         }
     }
@@ -51,10 +54,10 @@ impl Default for ResponseOptionsInner {
     }
 }
 
-impl ResponseOptionsInner{
+impl ResponseOptionsInner {
     // Creates a ResponseOptionsInner object with a default 200 status and no headers
     // Useful for server functions
-    pub fn default_without_headers() -> Self{
+    pub fn default_without_headers() -> Self {
         Self {
             status: Default::default(),
             headers: Headers::new(&[]),


### PR DESCRIPTION
Instead of only handling ActionForm/form submission in JS/WASM, implement default redirect of server functions back to the referrer