### PR TITLE
It is better to use the repository field

### DIFF
--- a/leptos-spin/Cargo.toml
+++ b/leptos-spin/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Spin support for Leptos"
 license = "Apache-2.0"
-homepage = "https://github.com/fermyon/leptos-spin"
+repository = "https://github.com/fermyon/leptos-spin"
 
 [dependencies]
 dashmap = "5.5.3"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).
