### PR TITLE
Drop `cfg-if` dependency from template

### DIFF
--- a/templates/leptos-ssr/content/Cargo.toml
+++ b/templates/leptos-ssr/content/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 anyhow = "1"
-cfg-if = "1"
 console_error_panic_hook = "0.1"
 http = "1.1"
 leptos = "0.6.6"

--- a/templates/leptos-ssr/content/src/lib.rs
+++ b/templates/leptos-ssr/content/src/lib.rs
@@ -3,20 +3,12 @@ mod app;
 #[cfg(feature = "ssr")]
 mod server;
 
-use cfg_if::cfg_if;
+#[cfg(feature = "hydrate")]
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub fn hydrate() {
+    use app::App;
 
-cfg_if! {
-if #[cfg(feature = "hydrate")] {
+    console_error_panic_hook::set_once();
 
-  use wasm_bindgen::prelude::wasm_bindgen;
-
-    #[wasm_bindgen]
-    pub fn hydrate() {
-      use app::*;
-
-      console_error_panic_hook::set_once();
-
-      leptos::mount_to_body(App);
-    }
-}
+    leptos::mount_to_body(App);
 }


### PR DESCRIPTION
The new code looks more readable IMO.

As a minor change, rewrite the `App` import from `app::*` to `app::App`. From Leptos v0.3.0 is no longer needed and the current *Cargo.toml* is pinning it to v0.6.6.