### PR TITLE
Drop `http` and `serde` dependencies from template

### DIFF
--- a/templates/leptos-ssr/content/Cargo.toml
+++ b/templates/leptos-ssr/content/Cargo.toml
@@ -17,7 +17,6 @@ leptos_integration_utils = { version = "0.6.6", optional = true }
 leptos_meta = "0.6.6"
 leptos_router = "0.6.6"
 leptos-spin = { version = "0.2.0", optional = true }
-serde = "1.0.192"
 spin-sdk = { version = "3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 

--- a/templates/leptos-ssr/content/Cargo.toml
+++ b/templates/leptos-ssr/content/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = [ "cdylib" ]
 anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
-http = "1.1"
 leptos = "0.6.6"
 leptos_integration_utils = { version = "0.6.6", optional = true }
 leptos_meta = "0.6.6"


### PR DESCRIPTION
They seem to be there from the first version of the template but never have been used.