### PR TITLE
Remove two Meta tags that caused apps to fail on Fermyon Cloud

### DIFF
--- a/templates/leptos-ssr/content/src/app.rs
+++ b/templates/leptos-ssr/content/src/app.rs
@@ -31,8 +31,6 @@ pub fn App() -> impl IntoView {
     view! {
         <Meta name="charset" content="UTF-8"/>
         <Meta name="description" content="A website running its server-side as a WASI Component :D"/>
-        <Meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <Meta name="theme-color" content="white"/>
 
         <Title text="Welcome to Leptos X Spin!"/>
 


### PR DESCRIPTION
I don't know why.  And it seems completely implausible.  But these two tags cause Fermyon Cloud to fail to prepare the application, which usually happens only if there's an unavailable Wasm import or something.  So I'll take them out for now until we can figure out what the conflict is...

cc @ogghead for pointing out how this introduces a different error scenario...!  _grin_
