### PR TITLE
Use wasip2 to inexplicably allow more meta

### DIFF
--- a/templates/leptos-ssr/content/spin.toml
+++ b/templates/leptos-ssr/content/spin.toml
@@ -11,11 +11,11 @@ route = "/..."
 component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
-source = "target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
+source = "target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
 allowed_outbound_hosts = []
 key_value_stores = ["default"]
 [component.{{project-name | kebab_case}}.build]
-command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME={{project-name | snake_case}} cargo build --lib --target wasm32-wasip1 --release --no-default-features --features ssr"
+command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME={{project-name | snake_case}} cargo build --lib --target wasm32-wasip2 --release --no-default-features --features ssr"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [[trigger.http]]

--- a/templates/leptos-ssr/content/src/app.rs
+++ b/templates/leptos-ssr/content/src/app.rs
@@ -32,6 +32,7 @@ pub fn App() -> impl IntoView {
     view! {
         <Stylesheet id="leptos" href="/pkg/{{project-name | snake_case}}.css"/>
         <Meta name="description" content="A website running its server-side as a WASI Component :D"/>
+        <Meta name="theme-color" content="white"/>
 
         <Title text="Welcome to Leptos X Spin!"/>
 


### PR DESCRIPTION
* Curiously, using wasip2 allows utilizing more meta tags!
* Tested by
  * Running `spin up --build` + making sure app is functional to verify local run
  * Deploying to Spin cloud with `spin cloud deploy` and verifying that with wasip2, app spins up