### PR TITLE
Add Spin support to leptos_wasi with flexible feature flags

### DIFF
--- a/templates/leptos-ssr/content/Cargo.toml.tmpl
+++ b/templates/leptos-ssr/content/Cargo.toml.tmpl
@@ -3,7 +3,7 @@ name = "{{project-name | kebab_case}}"
 authors = ["{{authors}}"]
 description = ""
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = [ "cdylib" ]

--- a/templates/leptos-ssr/content/Cargo.toml.tmpl
+++ b/templates/leptos-ssr/content/Cargo.toml.tmpl
@@ -9,15 +9,15 @@ edition = "2021"
 crate-type = [ "cdylib" ]
 
 [dependencies]
+any_spawner = { version = "0.3.0", features = ["async-executor", "futures-executor"] }
 console_error_panic_hook = "0.1"
-leptos = { version = "0.7.0" }
-leptos_meta = { version = "0.7.0" }
-leptos_router = { version = "0.7.0" }
-leptos_wasi = { version = "0.1.3", optional = true }
-spin-sdk = { version = "3", optional = true }
-# `wasi` needs to be locked until https://github.com/fermyon/spin/issues/2928 lands in a release
-wasi = { version = "=0.13.2", optional = true }
-wasm-bindgen = { version = "=0.2.96", optional = true }
+leptos = { version = "0.8.9" }
+leptos_meta = { version = "0.8.5" }
+leptos_router = { version = "0.8.7" }
+leptos_wasi = { version = "0.1.4", default-features = false, features = ["spin"], optional = true }
+spin-sdk = { version = "5.0.0", optional = true }
+wasi = { version = "0.14.7+wasi-0.2.4", optional = true }
+wasm-bindgen = { version = "0.2.103", optional = true }
 
 [workspace]
 

--- a/templates/leptos-ssr/content/src/server.rs
+++ b/templates/leptos-ssr/content/src/server.rs
@@ -1,7 +1,7 @@
-use leptos::{
-    config::get_configuration,
-    task::Executor as LeptosExecutor
-};
+use any_spawner::Executor as LeptosExecutor;
+
+use leptos::config::get_configuration;
+
 use leptos_wasi::{
     handler::HandlerError,
     prelude::{IncomingRequest, ResponseOutparam, WasiExecutor},


### PR DESCRIPTION

### Overview
This PR adds comprehensive support for both Spin and non-Spin environments to `leptos_wasi`, enabling developers to build Leptos applications that can run seamlessly in different WebAssembly environments.

### Key Changes
- **Feature Flags**: Added granular feature flags (`"spin"`, `"generic"`) to support different runtime environments
- **Flexible Architecture**: Core functionality remains runtime-agnostic while allowing runtime-specific optimizations
- **Improved Compatibility**: Enhanced compatibility with the latest Spin SDK and WASI specifications

### Usage

This is related to the PR i made https://github.com/leptos-rs/leptos_wasi/pull/16 bumping leptos wasi to 0.1.4

To use `leptos_wasi` with Spin support:

```toml
leptos_wasi = { version = "0.1.4", default-features = false, features = ["spin"] }
```

For non-Spin WASI environments:

```toml
leptos_wasi = { version = "0.1.4", default-features = false, features = ["generic"] } 
# or you can ignore  feature flag as the default is generic
leptos_wasi = { version = "0.1.4" } 
```

### Demo
🚀 **Live Demo**: Watch the complete workflow in action: 

https://github.com/user-attachments/assets/98d2402a-d82e-426c-95c7-eb21d696ae75

### Dependencies
- `leptos = "0.8.9"`
- `spin-sdk = "5.0.0"` (Spin environments only)
- `wasi = "0.14.7+wasi-0.2.4"`

