### PR TITLE
chore: update leptos_wasi git hash and wasi dependency version

### DIFF
--- a/templates/leptos-spin/content/Cargo.toml
+++ b/templates/leptos-spin/content/Cargo.toml
@@ -16,9 +16,9 @@ console_error_panic_hook = "0.1"
 leptos = { version = "0.8.9" }
 leptos_meta = { version = "0.8.5" }
 leptos_router = { version = "0.8.7" }
-leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "216acc484b0d6fe4b18876f1c96b68272498592b", default-features = false, features = ["wasip3"], optional = true }
+leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "0ee7282c8115e5747cbd3d61a375d805601ca6ef", default-features = false, features = ["wasip3"], optional = true }
 spin-sdk = { version = "6.0.0", optional = true }
-wasi = { version = "=0.13.1", optional = true }
+wasi = { version = "0.14.7", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
 wasm-bindgen = { version = "=0.2.103", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }

--- a/templates/leptos-spin/content/Cargo.toml
+++ b/templates/leptos-spin/content/Cargo.toml
@@ -16,11 +16,11 @@ console_error_panic_hook = "0.1"
 leptos = { version = "0.8.9" }
 leptos_meta = { version = "0.8.5" }
 leptos_router = { version = "0.8.7" }
-leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "0ee7282c8115e5747cbd3d61a375d805601ca6ef", default-features = false, features = ["wasip3"], optional = true }
+leptos_wasi = { version = "0.3.1", default-features = false, features = ["wasip3"], optional = true }
 spin-sdk = { version = "6.0.0", optional = true }
 wasi = { version = "0.14.7", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "=0.2.103", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [workspace]

--- a/templates/leptos-wasmtime/content/Cargo.toml
+++ b/templates/leptos-wasmtime/content/Cargo.toml
@@ -19,7 +19,7 @@ hydration_context = { version = "0.3.0" }
 leptos = { version = "0.8.9" }
 leptos_meta = { version = "0.8.5" }
 leptos_router = { version = "0.8.7" }
-leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "216acc484b0d6fe4b18876f1c96b68272498592b", default-features = false, features = ["wasip3"], optional = true }
+leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "0ee7282c8115e5747cbd3d61a375d805601ca6ef", default-features = false, features = ["wasip3"], optional = true }
 server_fn = { version = "0.8.7", features = ["axum-no-default"] }
 spin-sdk = { version = "6.0.0", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }

--- a/templates/leptos-wasmtime/content/Cargo.toml
+++ b/templates/leptos-wasmtime/content/Cargo.toml
@@ -19,11 +19,11 @@ hydration_context = { version = "0.3.0" }
 leptos = { version = "0.8.9" }
 leptos_meta = { version = "0.8.5" }
 leptos_router = { version = "0.8.7" }
-leptos_wasi = { git = "https://github.com/leptos-rs/leptos_wasi", rev = "0ee7282c8115e5747cbd3d61a375d805601ca6ef", default-features = false, features = ["wasip3"], optional = true }
+leptos_wasi = { version = "0.3.1", default-features = false, features = ["wasip3"], optional = true }
 server_fn = { version = "0.8.7", features = ["axum-no-default"] }
 spin-sdk = { version = "6.0.0", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "=0.2.103", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [features]


### PR DESCRIPTION
This PR updates the dependency references in the templates:
- Updates `leptos_wasi` to the latest commit `0ee7282c8115e5747cbd3d61a375d805601ca6ef` from `leptos-rs/leptos_wasi`.
- Upgrades `wasi` dependency to version `0.14.7`.