### PR TITLE
chore: lock wasm-bindgen to =0.2.114 and update leptos dependencies

### DIFF
--- a/templates/leptos-spin/content/Cargo.toml
+++ b/templates/leptos-spin/content/Cargo.toml
@@ -13,14 +13,14 @@ crate-type = [ "cdylib" ]
 any_spawner = { version = "0.3.0", features = ["futures-executor"] }
 anyhow = "1"
 console_error_panic_hook = "0.1"
-leptos = { version = "0.8.9" }
-leptos_meta = { version = "0.8.5" }
-leptos_router = { version = "0.8.7" }
+leptos = { version = "0.8.19" }
+leptos_meta = { version = "0.8.6" }
+leptos_router = { version = "0.8.13" }
 leptos_wasi = { version = "0.3.1", default-features = false, features = ["wasip3"], optional = true }
 spin-sdk = { version = "6.0.0", optional = true }
 wasi = { version = "0.14.7", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "=0.2.114", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [workspace]

--- a/templates/leptos-wasmtime/content/Cargo.toml
+++ b/templates/leptos-wasmtime/content/Cargo.toml
@@ -16,14 +16,14 @@ bytes = "1.7.2"
 console_error_panic_hook = "0.1"
 futures = "0.3.30"
 hydration_context = { version = "0.3.0" }
-leptos = { version = "0.8.9" }
-leptos_meta = { version = "0.8.5" }
-leptos_router = { version = "0.8.7" }
+leptos = { version = "0.8.19" }
+leptos_meta = { version = "0.8.6" }
+leptos_router = { version = "0.8.13" }
 leptos_wasi = { version = "0.3.1", default-features = false, features = ["wasip3"], optional = true }
-server_fn = { version = "0.8.7", features = ["axum-no-default"] }
+server_fn = { version = "0.8.12", features = ["axum-no-default"] }
 spin-sdk = { version = "6.0.0", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "=0.2.114", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [features]


### PR DESCRIPTION
This PR updates the dependencies in the Spin templates (`leptos-spin` and `leptos-wasmtime`) to their latest versions.

Additionally, it pins `wasm-bindgen` to `=0.2.114` to avoid a regression/issue introduced in newer versions of `wasm-bindgen`, as discussed in https://github.com/wasm-bindgen/wasm-bindgen/pull/5175. Once that PR is merged and released, we can revert back to using the relaxed `^0.2` dependency constraint.

### Changes
* **`leptos`**: updated to `0.8.19`
* **`leptos_meta`**: updated to `0.8.6`
* **`leptos_router`**: updated to `0.8.13`
* **`server_fn`** (in `leptos-wasmtime` template): updated to `0.8.12`
* **`wasm-bindgen`**: locked to `=0.2.114`